### PR TITLE
Links only for projects which have modules enabled

### DIFF
--- a/lib/my_projects/view_hook_listener.rb
+++ b/lib/my_projects/view_hook_listener.rb
@@ -46,8 +46,12 @@ class MyProjects < Redmine::Hook::ViewListener
   def link_to_project(project)
     html = '<li>'
     html += "#{link_to h(project.name), { :controller => 'projects', :action => 'show', :id => project } }"
-    html += " | #{link_to l(:label_issue_plural), { :controller => 'issues', :action=>'index', :project_id => project } } "
-    html += " | #{link_to l(:label_wiki), { :controller => 'wiki', :action=>'show', :project_id => project } } "
+    if project.enabled_module_names.include? 'issue_tracking'
+      html += " | #{link_to l(:label_issue_plural), { :controller => 'issues', :action=>'index', :project_id => project } } "
+    end
+    if project.enabled_module_names.include? 'wiki'
+      html += " | #{link_to l(:label_wiki), { :controller => 'wiki', :action=>'show', :project_id => project } } "
+    end
     html += '</li>'
     
     return html


### PR DESCRIPTION
This commit adds functionality to the plugin so that the "Issues" and/or "Wiki" links only appear for projects which have those modules enabled.
